### PR TITLE
feat(redis): Add `REDIS_FAMILY` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Please note that on the interface, the Redis server info button will not work. F
 * `REDIS_USE_TLS` - enable TLS true or false (`false` by default)
 * `REDIS_USER` - user to connect to redis (no user by default)
 * `REDIS_PASSWORD` - password to connect to redis (no password by default)
+* `REDIS_FAMILY` - either 4 or 6, defaults to 4
 * `SENTINEL_NAME` - name of sentinel instance (required with sentinel)
 * `SENTINEL_HOSTS` - a string containing a list of replica servers (e.g. '1.redis:26379,2.redis:26379,3.redis:26379'), overrides `REDIS_HOST` + `REDIS_PORT` configuration (you can use `,` or `;`)
 * `MAX_RETRIES_PER_REQUEST` - makes sure commands won't wait forever when the connection is down (disabled `null` by default)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Please note that on the interface, the Redis server info button will not work. F
 * `REDIS_USE_TLS` - enable TLS true or false (`false` by default)
 * `REDIS_USER` - user to connect to redis (no user by default)
 * `REDIS_PASSWORD` - password to connect to redis (no password by default)
-* `REDIS_FAMILY` - either 4 or 6, defaults to 4
+* `REDIS_FAMILY` - IP Stack version (one of 4 | 6 | 0) (`0` by default)
 * `SENTINEL_NAME` - name of sentinel instance (required with sentinel)
 * `SENTINEL_HOSTS` - a string containing a list of replica servers (e.g. '1.redis:26379,2.redis:26379,3.redis:26379'), overrides `REDIS_HOST` + `REDIS_PORT` configuration (you can use `,` or `;`)
 * `MAX_RETRIES_PER_REQUEST` - makes sure commands won't wait forever when the connection is down (disabled `null` by default)

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ export const config = {
 	REDIS_USER: process.env.REDIS_USER,
 	REDIS_PASSWORD: process.env.REDIS_PASSWORD,
 	REDIS_USE_TLS: process.env.REDIS_USE_TLS,
-	REDIS_FAMILY: Number(process.env.REDIS_FAMILY) || 4,
+	REDIS_FAMILY: Number(process.env.REDIS_FAMILY) || 0,
 	BULL_PREFIX: process.env.BULL_PREFIX || 'bull',
 	BULL_VERSION: process.env.BULL_VERSION || 'BULLMQ',
 	PORT: process.env.PORT || 3000,

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ export const config = {
 	REDIS_USER: process.env.REDIS_USER,
 	REDIS_PASSWORD: process.env.REDIS_PASSWORD,
 	REDIS_USE_TLS: process.env.REDIS_USE_TLS,
+	REDIS_FAMILY: Number(process.env.REDIS_FAMILY) || 4,
 	BULL_PREFIX: process.env.BULL_PREFIX || 'bull',
 	BULL_VERSION: process.env.BULL_VERSION || 'BULLMQ',
 	PORT: process.env.PORT || 3000,

--- a/src/redis.js
+++ b/src/redis.js
@@ -20,6 +20,7 @@ export const redisConfig = {
 		...(!config.SENTINEL_HOSTS && {
 			port: config.REDIS_PORT,
 			host: config.REDIS_HOST,
+			family: config.REDIS_FAMILY,
 		}),
 		db: config.REDIS_DB,
 		...(config.REDIS_USER && {


### PR DESCRIPTION
Some host providers like fly.io only have IPv6 private networks.  In such configuration, redis clients expects `family` to be set to `6`, alongside `host` and `port`.  Without this it will simply be impossible to connect to the deployed Redis instance on those IPv6 private networks.

This adds a new `REDIS_FAMILY` env var that defaults to redis default `0`.