### PR TITLE
Add sentinel password

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Please note that on the interface, the Redis server info button will not work. F
 * `REDIS_PASSWORD` - password to connect to redis (no password by default)
 * `REDIS_FAMILY` - IP Stack version (one of 4 | 6 | 0) (`0` by default)
 * `SENTINEL_NAME` - name of sentinel instance (required with sentinel)
-* `SENTINEL_HOSTS` - a string containing a list of replica servers (e.g. '1.redis:26379,2.redis:26379,3.redis:26379'), overrides `REDIS_HOST` + `REDIS_PORT` configuration (you can use `,` or `;`)
+* `SENTINEL_HOSTS` - a string containing a list of sentinel servers (e.g. '1.redis:26379,2.redis:26379,3.redis:26379'), overrides `REDIS_HOST` + `REDIS_PORT` configuration (you can use `,` or `;`)
+* `SENTINEL_PASSWORD` - password to connect to sentinel (no password by default)
 * `MAX_RETRIES_PER_REQUEST` - makes sure commands won't wait forever when the connection is down (disabled `null` by default)
 
 **Interface**

--- a/examples/sentinel-example/docker-compose.yml
+++ b/examples/sentinel-example/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       BULL_VERSION: BULL
       SENTINEL_NAME: mymaster
       SENTINEL_HOSTS: "redis-sentinel1:26379;redis-sentinel2:26380;redis-sentinel3:26381"
+      REDIS_PASSWORD: password
+      SENTINEL_PASSWORD: sentinel-password
     restart: unless-stopped
     ports:
       - "3000:3000"
@@ -35,6 +37,7 @@ services:
     environment:
       ALLOW_EMPTY_PASSWORD: yes
       REDIS_REPLICATION_MODE: master
+      REDIS_PASSWORD: password
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -54,6 +57,8 @@ services:
       ALLOW_EMPTY_PASSWORD: yes
       REDIS_REPLICATION_MODE: slave
       REDIS_MASTER_HOST: redis-master
+      REDIS_MASTER_PASSWORD: password
+      REDIS_PASSWORD: password
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -74,6 +79,8 @@ services:
       ALLOW_EMPTY_PASSWORD: yes
       REDIS_REPLICATION_MODE: slave
       REDIS_MASTER_HOST: redis-master
+      REDIS_MASTER_PASSWORD: password
+      REDIS_PASSWORD: password
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -97,6 +104,7 @@ services:
     environment:
       REDIS_MASTER_HOST: redis-master
       REDIS_SENTINEL_PORT_NUMBER: 26379
+      REDIS_SENTINEL_PASSWORD: sentinel-password
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "26379", "ping"]
       interval: 10s
@@ -122,6 +130,7 @@ services:
     environment:
       REDIS_MASTER_HOST: redis-master
       REDIS_SENTINEL_PORT_NUMBER: 26380
+      REDIS_SENTINEL_PASSWORD: sentinel-password
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "26380", "ping"]
       interval: 10s
@@ -147,6 +156,7 @@ services:
     environment:
       REDIS_MASTER_HOST: redis-master
       REDIS_SENTINEL_PORT_NUMBER: 26381
+      REDIS_SENTINEL_PASSWORD: sentinel-password
     healthcheck:
       test: ["CMD", "redis-cli", "-p", "26381", "ping"]
       interval: 10s

--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,7 @@ export const config = {
 	REDIS_FAMILY: Number(process.env.REDIS_FAMILY) || 0,
 	SENTINEL_NAME: process.env.SENTINEL_NAME,
 	SENTINEL_HOSTS: process.env.SENTINEL_HOSTS,
+	SENTINEL_PASSWORD: process.env.SENTINEL_PASSWORD,
 	MAX_RETRIES_PER_REQUEST: process.env.MAX_RETRIES_PER_REQUEST,
 
 	// Queue configuration

--- a/src/redis.js
+++ b/src/redis.js
@@ -14,6 +14,7 @@ export const redisConfig = {
 	redis: {
 		...(config.SENTINEL_HOSTS && {
 			sentinels: parseDSNToSentinels(config.SENTINEL_HOSTS),
+			sentinelPassword: config.SENTINEL_PASSWORD,
 			name: config.SENTINEL_NAME,
 			maxRetriesPerRequest: config.MAX_RETRIES_PER_REQUEST || null,
 		}),


### PR DESCRIPTION
# 🚀 Support password-protected Sentinel instances

## 📦 What's in the box?

- [X] Added `SENTINEL_PASSWORD` environment variable
- [X] Feed the sentinel password to `ioredis`
- [X] Updated documentation
- [X] Updated docker-compose testing/example stack

## 🤖 How to test it?

Run the updated examples/sentinel-example docker-compose stack with a bull-board image built from my branch (either locally or temporarily available at `docker.io/thepoon/bull-board-docker:latest`).
