### PR TITLE
feat(config): add HOSTNAME environment variable

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -30,6 +30,7 @@ export const config = {
 	BACKOFF_NB_ATTEMPTS: process.env.BACKOFF_NB_ATTEMPTS || 10,
 
 	// App configuration
+	HOSTNAME: process.env.HOSTNAME || "localhost",
 	PORT: process.env.PORT || 3000,
 	PROXY_PATH: PROXY_PATH,
 	USER_LOGIN: process.env.USER_LOGIN,

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ app.use('/healthcheck', async (req, res) => {
 	});
 });
 
-app.listen(config.PORT, () => {
-	console.log(`bull-board is started http://localhost:${config.PORT}${config.HOME_PAGE}`);
+app.listen(config.PORT, config.HOSTNAME, () => {
+	console.log(`bull-board is started http://${config.HOSTNAME}:${config.PORT}${config.HOME_PAGE}`);
 	console.log(`bull-board is fetching queue list, please wait...`);
 });


### PR DESCRIPTION
# 🚀 Add HOSTNAME environment variable

Binding to `localhost` forces ports forwarding which is not always optimal. Now the `HOSTNAME` variable can be set to `0.0.0.0` to allow connections from other containers, e.g. reverse-proxies.

## 📦 What's in the box?

- [x] Added HOSTNAME environment variable
- [x] Added HOSTNAME config with the default value of `localhost`

## 🤖 How to test it?

```yaml
bull-board:
  build: https://github.com/ClayenKitten/bull-board-docker.git#host
  restart: unless-stopped
  expose: [3000]
  environment:
    HOST: 0.0.0.0
    REDIS_HOST: redis
```