### PR TITLE
perf: use SCAN instead of KEYS and add graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Please note that on the interface, the Redis server info button will not work. F
 * `USER_LOGIN` - login to restrict access to bull-board interface (disabled by default)
 * `USER_PASSWORD` - password to restrict access to bull-board interface (disabled by default)
 
+**Graceful shutdown**
+* `GRACEFUL_SHUTDOWN_TIMEOUT` - Maximum time in milliseconds to wait for the server to close before forcing shutdown (`10000` by default)
+
 **Queue setup**
 * `BULL_PREFIX` - prefix to your bull queue name (`bull` by default)
 * `BULL_VERSION` - version of bull lib to use 'BULLMQ' or 'BULL' (`BULLMQ` by default)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ A Healthcheck based on NestJS is available to monitor the status of the containe
 | `error`   | String containing information of each health indicator which is of status 'down', or in other words "unhealthy". | string          |
 | `details` | Object containing all information of each health indicator                                                       | object          |
 
+The endpoint returns `200 OK` when healthy and `503 Service Unavailable` when Redis is unreachable.
+
+> **Use as a readiness probe, not a liveness probe.** A transient Redis outage will return 503 — if `/healthcheck` is wired as a Kubernetes `livenessProbe`, the pod will be killed and restarted on every Redis blip (which doesn't help, since restarting bull-board doesn't fix Redis). Use it as a `readinessProbe` so the pod is removed from the load balancer until Redis recovers, without being killed.
+
 ### Example with docker-compose
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Please note that on the interface, the Redis server info button will not work. F
 - `USER_LOGIN` - login to restrict access to bull-board interface (disabled by default)
 - `USER_PASSWORD` - password to restrict access to bull-board interface (disabled by default)
 
+**Graceful shutdown**
+
+- `GRACEFUL_SHUTDOWN_TIMEOUT` - Maximum time in milliseconds to wait for the server to close before forcing shutdown (`10000` by default). Set to `0` to disable the force-kill timer and always wait for a clean close.
+
 **Queue setup**
 
 - `BULL_PREFIX` - prefix to your bull queue name (`bull` by default)
@@ -205,6 +209,10 @@ A Healthcheck based on NestJS is available to monitor the status of the containe
 | `info`    | Object containing information of each health indicator which is of status 'up', or in other words "healthy".     | object          |
 | `error`   | String containing information of each health indicator which is of status 'down', or in other words "unhealthy". | string          |
 | `details` | Object containing all information of each health indicator                                                       | object          |
+
+The endpoint returns `200 OK` when healthy and `503 Service Unavailable` when Redis is unreachable.
+
+> **Use as a readiness probe, not a liveness probe.** A transient Redis outage will return 503 — if `/healthcheck` is wired as a Kubernetes `livenessProbe`, the pod will be killed and restarted on every Redis blip (which doesn't help, since restarting bull-board doesn't fix Redis). Use it as a `readinessProbe` so the pod is removed from the load balancer until Redis recovers, without being killed.
 
 ### Example with docker-compose
 

--- a/src/bull.js
+++ b/src/bull.js
@@ -89,7 +89,7 @@ async function getRedisKeys(pattern) {
 		if (fulfilled.length === 0) {
 			throw new Error('All master nodes failed during key scan');
 		}
-		return fulfilled.flatMap(r => r.value);
+		return [...new Set(fulfilled.flatMap(r => r.value))];
 	}
 	try {
 		return await scanForKeys(client, pattern);
@@ -99,35 +99,33 @@ async function getRedisKeys(pattern) {
 	}
 }
 
+function createBullMQAdapter(name) {
+	return new BullMQAdapter(new Queue(name, {
+		connection: isCluster ? client : redisConfig.redis,
+		...(config.BULL_PREFIX && {prefix: config.BULL_PREFIX})
+	}, client.connection));
+}
+
+function createBullAdapter(name) {
+	return new BullAdapter(new Bull(name, {
+		...(isCluster
+			? { createClient: () => {
+				const dup = client.duplicate();
+				dup.on('error', (err) => console.error(`Redis Cluster duplicate client error (queue "${name}"):`, err));
+				return dup;
+			}}
+			: { redis: redisConfig.redis }),
+		...(config.BULL_PREFIX && {prefix: config.BULL_PREFIX})
+	}, client.connection));
+}
+
 async function getBullQueues() {
 	assertBullClusterPrefix();
 	const keys = await getRedisKeys(`${config.BULL_PREFIX}:*`);
 	const uniqKeys = new Set(keys.map(key => key.replace(/^.+?:(.+?):.+?$/, '$1')));
 
-	// This increases the number of connections.
-	// Example: on a cluster I went from an average of 100 to 28k
-	// const uniqKeys = new Set(keys.map(key => key.replace(
-	// 	new RegExp(`^${config.BULL_PREFIX}:(.+):[^:]+$`),
-	// 	'$1'
-	// )));
-
-	const queueList = Array.from(uniqKeys).sort().map(
-		(item) => config.BULL_VERSION === 'BULLMQ' ?
-			new BullMQAdapter(new Queue(item, {
-				connection: isCluster ? client : redisConfig.redis,
-				...(config.BULL_PREFIX && {prefix: config.BULL_PREFIX})
-			}, client.connection)) :
-			new BullAdapter(new Bull(item, {
-				...(isCluster
-					? { createClient: () => {
-						const dup = client.duplicate();
-						dup.on('error', (err) => console.error(`Redis Cluster duplicate client error (queue "${item}"):`, err));
-						return dup;
-					}}
-					: { redis: redisConfig.redis }),
-				...(config.BULL_PREFIX && {prefix: config.BULL_PREFIX})
-			}, client.connection))
-	);
+	const createAdapter = config.BULL_VERSION === 'BULLMQ' ? createBullMQAdapter : createBullAdapter;
+	const queueList = Array.from(uniqKeys).sort().map(createAdapter);
 	if (queueList.length === 0) {
 		throw new Error("No queue found.");
 	}

--- a/src/bull.js
+++ b/src/bull.js
@@ -91,12 +91,7 @@ async function getRedisKeys(pattern) {
 		}
 		return [...new Set(fulfilled.flatMap(r => r.value))];
 	}
-	try {
-		return await scanForKeys(client, pattern);
-	} catch (err) {
-		console.warn('SCAN failed, falling back to KEYS:', err.message);
-		return client.keys(pattern);
-	}
+	return scanForKeys(client, pattern);
 }
 
 function createBullMQAdapter(name) {

--- a/src/bull.js
+++ b/src/bull.js
@@ -11,6 +11,9 @@ import { config } from "./config.js";
 
 const BULL_CLUSTER_PREFIX_REQUIRED = "BULL_CLUSTER_PREFIX_REQUIRED";
 
+// Number of keys SCAN hints Redis to return per iteration (COUNT is a hint, not a limit).
+const REDIS_SCAN_COUNT = 100;
+
 const serverAdapter = new ExpressAdapter();
 const { setQueues } = createBullBoard({
 	queues: [],
@@ -66,13 +69,32 @@ function assertBullClusterPrefix() {
 	}
 }
 
+async function scanForKeys(redisClient, pattern) {
+	const keys = [];
+	let cursor = "0";
+	do {
+		const [nextCursor, foundKeys] = await redisClient.scan(
+			cursor,
+			"MATCH",
+			pattern,
+			"COUNT",
+			REDIS_SCAN_COUNT,
+		);
+		cursor = nextCursor;
+		keys.push(...foundKeys);
+	} while (cursor !== "0");
+	// SCAN may return the same key across iterations; dedupe so both the
+	// single-node and per-master cluster paths return unique keys.
+	return [...new Set(keys)];
+}
+
 async function getRedisKeys(pattern) {
 	if (isCluster) {
 		const masters = client.nodes("master");
 		if (!masters || masters.length === 0) {
 			throw new Error("No master nodes available in the Redis Cluster");
 		}
-		const results = await Promise.allSettled(masters.map((node) => node.keys(pattern)));
+		const results = await Promise.allSettled(masters.map((node) => scanForKeys(node, pattern)));
 		const fulfilled = results.filter((r) => r.status === "fulfilled");
 		const rejected = results.filter((r) => r.status === "rejected");
 		if (rejected.length > 0) {
@@ -84,9 +106,45 @@ async function getRedisKeys(pattern) {
 		if (fulfilled.length === 0) {
 			throw new Error("All master nodes failed during key scan");
 		}
-		return fulfilled.flatMap((r) => r.value);
+		return [...new Set(fulfilled.flatMap((r) => r.value))];
 	}
-	return client.keys(pattern);
+	return scanForKeys(client, pattern);
+}
+
+function createBullMQAdapter(name) {
+	return new BullMQAdapter(
+		new Queue(
+			name,
+			{
+				connection: isCluster ? client : redisConfig.redis,
+				...(config.BULL_PREFIX && { prefix: config.BULL_PREFIX }),
+			},
+			client.connection,
+		),
+	);
+}
+
+function createBullAdapter(name) {
+	return new BullAdapter(
+		new Bull(
+			name,
+			{
+				...(isCluster
+					? {
+							createClient: () => {
+								const dup = client.duplicate();
+								dup.on("error", (err) =>
+									console.error(`Redis Cluster duplicate client error (queue "${name}"):`, err),
+								);
+								return dup;
+							},
+						}
+					: { redis: redisConfig.redis }),
+				...(config.BULL_PREFIX && { prefix: config.BULL_PREFIX }),
+			},
+			client.connection,
+		),
+	);
 }
 
 async function getBullQueues() {
@@ -94,51 +152,8 @@ async function getBullQueues() {
 	const keys = await getRedisKeys(`${config.BULL_PREFIX}:*`);
 	const uniqKeys = new Set(keys.map((key) => key.replace(/^.+?:(.+?):.+?$/, "$1")));
 
-	// This increases the number of connections.
-	// Example: on a cluster I went from an average of 100 to 28k
-	// const uniqKeys = new Set(keys.map(key => key.replace(
-	// 	new RegExp(`^${config.BULL_PREFIX}:(.+):[^:]+$`),
-	// 	'$1'
-	// )));
-
-	const queueList = Array.from(uniqKeys)
-		.sort()
-		.map((item) =>
-			config.BULL_VERSION === "BULLMQ"
-				? new BullMQAdapter(
-						new Queue(
-							item,
-							{
-								connection: isCluster ? client : redisConfig.redis,
-								...(config.BULL_PREFIX && { prefix: config.BULL_PREFIX }),
-							},
-							client.connection,
-						),
-					)
-				: new BullAdapter(
-						new Bull(
-							item,
-							{
-								...(isCluster
-									? {
-											createClient: () => {
-												const dup = client.duplicate();
-												dup.on("error", (err) =>
-													console.error(
-														`Redis Cluster duplicate client error (queue "${item}"):`,
-														err,
-													),
-												);
-												return dup;
-											},
-										}
-									: { redis: redisConfig.redis }),
-								...(config.BULL_PREFIX && { prefix: config.BULL_PREFIX }),
-							},
-							client.connection,
-						),
-					),
-		);
+	const createAdapter = config.BULL_VERSION === "BULLMQ" ? createBullMQAdapter : createBullAdapter;
+	const queueList = Array.from(uniqKeys).sort().map(createAdapter);
 	if (queueList.length === 0) {
 		throw new Error("No queue found.");
 	}

--- a/src/config.js
+++ b/src/config.js
@@ -102,10 +102,10 @@ export const config = {
 	// Queue configuration
 	BULL_PREFIX: process.env.BULL_PREFIX || 'bull',
 	BULL_VERSION: process.env.BULL_VERSION || 'BULLMQ',
-	BACKOFF_STARTING_DELAY: process.env.BACKOFF_STARTING_DELAY || 500,
-	BACKOFF_MAX_DELAY: process.env.BACKOFF_MAX_DELAY || Infinity,
-	BACKOFF_TIME_MULTIPLE: process.env.BACKOFF_TIME_MULTIPLE || 2,
-	BACKOFF_NB_ATTEMPTS: process.env.BACKOFF_NB_ATTEMPTS || 10,
+	BACKOFF_STARTING_DELAY: Number(process.env.BACKOFF_STARTING_DELAY) || 500,
+	BACKOFF_MAX_DELAY: Number(process.env.BACKOFF_MAX_DELAY) || Infinity,
+	BACKOFF_TIME_MULTIPLE: Number(process.env.BACKOFF_TIME_MULTIPLE) || 2,
+	BACKOFF_NB_ATTEMPTS: Number(process.env.BACKOFF_NB_ATTEMPTS) || 10,
 
 	// Shutdown configuration
 	GRACEFUL_SHUTDOWN_TIMEOUT: Number(process.env.GRACEFUL_SHUTDOWN_TIMEOUT) || 10000,

--- a/src/config.js
+++ b/src/config.js
@@ -107,6 +107,9 @@ export const config = {
 	BACKOFF_TIME_MULTIPLE: process.env.BACKOFF_TIME_MULTIPLE || 2,
 	BACKOFF_NB_ATTEMPTS: process.env.BACKOFF_NB_ATTEMPTS || 10,
 
+	// Shutdown configuration
+	GRACEFUL_SHUTDOWN_TIMEOUT: Number(process.env.GRACEFUL_SHUTDOWN_TIMEOUT) || 10000,
+
 	// App configuration
 	BULL_BOARD_HOSTNAME: process.env.BULL_BOARD_HOSTNAME || "0.0.0.0",
 	PORT: process.env.PORT || 3000,

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,12 @@ function normalizePath(pathStr) {
 
 export const PROXY_PATH = normalizePath(process.env.PROXY_PATH);
 
+function parseNumberEnv(value, defaultValue) {
+	if (value === undefined || value === "") return defaultValue;
+	const n = Number(value);
+	return Number.isNaN(n) ? defaultValue : n;
+}
+
 function parseBooleanEnv(value, defaultValue = false) {
 	if (value === undefined) return defaultValue;
 	const normalized = String(value).trim().toLowerCase();
@@ -113,13 +119,13 @@ export const config = {
 	// Queue configuration
 	BULL_PREFIX: process.env.BULL_PREFIX || "bull",
 	BULL_VERSION: process.env.BULL_VERSION || "BULLMQ",
-	BACKOFF_STARTING_DELAY: Number(process.env.BACKOFF_STARTING_DELAY) || 500,
-	BACKOFF_MAX_DELAY: Number(process.env.BACKOFF_MAX_DELAY) || Infinity,
-	BACKOFF_TIME_MULTIPLE: Number(process.env.BACKOFF_TIME_MULTIPLE) || 2,
-	BACKOFF_NB_ATTEMPTS: Number(process.env.BACKOFF_NB_ATTEMPTS) || 10,
+	BACKOFF_STARTING_DELAY: parseNumberEnv(process.env.BACKOFF_STARTING_DELAY, 500),
+	BACKOFF_MAX_DELAY: parseNumberEnv(process.env.BACKOFF_MAX_DELAY, Infinity),
+	BACKOFF_TIME_MULTIPLE: parseNumberEnv(process.env.BACKOFF_TIME_MULTIPLE, 2),
+	BACKOFF_NB_ATTEMPTS: parseNumberEnv(process.env.BACKOFF_NB_ATTEMPTS, 10),
 
 	// Shutdown configuration
-	GRACEFUL_SHUTDOWN_TIMEOUT: Number(process.env.GRACEFUL_SHUTDOWN_TIMEOUT) || 10000,
+	GRACEFUL_SHUTDOWN_TIMEOUT: parseNumberEnv(process.env.GRACEFUL_SHUTDOWN_TIMEOUT, 10000),
 
 	// App configuration
 	BULL_BOARD_HOSTNAME: process.env.BULL_BOARD_HOSTNAME || "0.0.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,12 @@ function normalizePath(pathStr) {
 
 export const PROXY_PATH = normalizePath(process.env.PROXY_PATH);
 
+function parseNumberEnv(value, defaultValue) {
+	if (value === undefined || value === "") return defaultValue;
+	const n = Number(value);
+	return Number.isNaN(n) ? defaultValue : n;
+}
+
 function parseBooleanEnv(value, defaultValue = false) {
 	if (value === undefined) return defaultValue;
 	const normalized = String(value).trim().toLowerCase();
@@ -113,10 +119,13 @@ export const config = {
 	// Queue configuration
 	BULL_PREFIX: process.env.BULL_PREFIX || "bull",
 	BULL_VERSION: process.env.BULL_VERSION || "BULLMQ",
-	BACKOFF_STARTING_DELAY: process.env.BACKOFF_STARTING_DELAY || 500,
-	BACKOFF_MAX_DELAY: process.env.BACKOFF_MAX_DELAY || Infinity,
-	BACKOFF_TIME_MULTIPLE: process.env.BACKOFF_TIME_MULTIPLE || 2,
-	BACKOFF_NB_ATTEMPTS: process.env.BACKOFF_NB_ATTEMPTS || 10,
+	BACKOFF_STARTING_DELAY: parseNumberEnv(process.env.BACKOFF_STARTING_DELAY, 500),
+	BACKOFF_MAX_DELAY: parseNumberEnv(process.env.BACKOFF_MAX_DELAY, Infinity),
+	BACKOFF_TIME_MULTIPLE: parseNumberEnv(process.env.BACKOFF_TIME_MULTIPLE, 2),
+	BACKOFF_NB_ATTEMPTS: parseNumberEnv(process.env.BACKOFF_NB_ATTEMPTS, 10),
+
+	// Shutdown configuration
+	GRACEFUL_SHUTDOWN_TIMEOUT: parseNumberEnv(process.env.GRACEFUL_SHUTDOWN_TIMEOUT, 10000),
 
 	// App configuration
 	BULL_BOARD_HOSTNAME: process.env.BULL_BOARD_HOSTNAME || "0.0.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ const gracefulShutdown = (signal) => {
 	setTimeout(() => {
 		console.error('Forced shutdown after timeout');
 		process.exit(1);
-	}, 10000).unref();
+	}, config.GRACEFUL_SHUTDOWN_TIMEOUT).unref();
 }
 
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,12 @@ const server = app.listen(config.PORT, config.BULL_BOARD_HOSTNAME, () => {
 	console.log(`bull-board is fetching queue list, please wait...`);
 });
 
+let isShuttingDown = false;
+
 const gracefulShutdown = (signal) => {
+	if (isShuttingDown) return;
+	isShuttingDown = true;
+
 	console.log(`\n${signal} received, starting graceful shutdown...`);
 
 	server.close(async () => {
@@ -107,7 +112,7 @@ const gracefulShutdown = (signal) => {
 	setTimeout(() => {
 		console.error('Forced shutdown after timeout');
 		process.exit(1);
-	}, 10000);
+	}, 10000).unref();
 }
 
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ app.use('/healthcheck', async (req, res) => {
 		redisError = err;
 	}
 
-	res.status(200).json({
+	res.status(status === 'ok' ? 200 : 503).json({
 		status,
 		info: {
 			redis: {

--- a/src/index.js
+++ b/src/index.js
@@ -103,14 +103,16 @@ const gracefulShutdown = (signal) => {
 	server.close(async () => {
 		console.log("HTTP server closed");
 
+		let exitCode = 0;
 		try {
 			await client.quit();
 			console.log("Redis connection closed");
 		} catch (err) {
 			console.error("Error closing Redis connection:", err);
+			exitCode = 1;
 		}
 
-		process.exit(0);
+		process.exit(exitCode);
 	});
 
 	setTimeout(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ app.use("/healthcheck", async (req, res) => {
 		redisError = err;
 	}
 
-	res.status(200).json({
+	res.status(status === "ok" ? 200 : 503).json({
 		status,
 		info: {
 			redis: {
@@ -85,9 +85,44 @@ app.use("/healthcheck", async (req, res) => {
 	});
 });
 
-app.listen(config.PORT, config.BULL_BOARD_HOSTNAME, () => {
+const server = app.listen(config.PORT, config.BULL_BOARD_HOSTNAME, () => {
 	console.log(
 		`bull-board is started http://${config.BULL_BOARD_HOSTNAME}:${config.PORT}${config.HOME_PAGE}`,
 	);
 	console.log(`bull-board is fetching queue list, please wait...`);
 });
+
+let isShuttingDown = false;
+
+const gracefulShutdown = (signal) => {
+	if (isShuttingDown) return;
+	isShuttingDown = true;
+
+	console.log(`\n${signal} received, starting graceful shutdown...`);
+
+	server.close(async () => {
+		console.log("HTTP server closed");
+
+		let exitCode = 0;
+		try {
+			await client.quit();
+			console.log("Redis connection closed");
+		} catch (err) {
+			console.error("Error closing Redis connection:", err);
+			exitCode = 1;
+		}
+
+		process.exit(exitCode);
+	});
+
+	// A timeout of 0 disables the force-kill timer and waits for a clean close.
+	if (config.GRACEFUL_SHUTDOWN_TIMEOUT > 0) {
+		setTimeout(() => {
+			console.error("Forced shutdown after timeout");
+			process.exit(1);
+		}, config.GRACEFUL_SHUTDOWN_TIMEOUT).unref();
+	}
+};
+
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));

--- a/src/redis.js
+++ b/src/redis.js
@@ -247,6 +247,8 @@ export const client =
 		? {
 				keys: () => Promise.resolve([]),
 				scan: () => Promise.resolve(["0", []]),
+				ping: () => Promise.resolve("PONG"),
+				quit: () => Promise.resolve("OK"),
 				connection: "mock-connection",
 				on: () => {},
 				nodes: () => [],

--- a/src/redis.js
+++ b/src/redis.js
@@ -246,11 +246,15 @@ export const client =
 	process.env.NODE_ENV === "test"
 		? {
 				keys: () => Promise.resolve([]),
+				scan: () => Promise.resolve(["0", []]),
+				ping: () => Promise.resolve("PONG"),
+				quit: () => Promise.resolve("OK"),
 				connection: "mock-connection",
 				on: () => {},
 				nodes: () => [],
 				duplicate: () => ({
 					keys: () => Promise.resolve([]),
+					scan: () => Promise.resolve(["0", []]),
 					on: () => {},
 				}),
 			}

--- a/src/redis.js
+++ b/src/redis.js
@@ -228,11 +228,13 @@ function createRedisClient() {
 export const client = process.env.NODE_ENV === 'test'
 	? {
 		keys: () => Promise.resolve([]),
+		scan: () => Promise.resolve(['0', []]),
 		connection: 'mock-connection',
 		on: () => {},
 		nodes: () => [],
 		duplicate: () => ({
 			keys: () => Promise.resolve([]),
+			scan: () => Promise.resolve(['0', []]),
 			on: () => {},
 		}),
 	}

--- a/tests/unit/bull.test.js
+++ b/tests/unit/bull.test.js
@@ -85,9 +85,11 @@ describe('Bull Queue Setup', () => {
 
 		// Setup Redis mock
 		clientKeysMock = vi.fn().mockResolvedValue(queueKeys);
+		const clientScanMock = vi.fn().mockResolvedValue(['0', queueKeys]);
 		vi.doMock('../../src/redis', () => ({
 			client: {
 				keys: clientKeysMock,
+				scan: clientScanMock,
 				connection: 'redis-connection',
 				on: vi.fn(),
 				nodes: vi.fn().mockReturnValue([]),

--- a/tests/unit/bull.test.js
+++ b/tests/unit/bull.test.js
@@ -182,6 +182,55 @@ describe("Bull Queue Setup", () => {
 		expect(setQueuesMock).toHaveBeenCalledWith(expect.any(Array));
 	});
 
+	it("should accumulate keys across multiple SCAN pages", async () => {
+		vi.doMock("bullmq", () => ({ Queue: vi.fn() }));
+		vi.doMock("bull", () => ({ default: vi.fn() }));
+		vi.doMock("@bull-board/api", () => ({
+			createBullBoard: vi.fn().mockReturnValue({ setQueues: vi.fn() }),
+		}));
+		vi.doMock("@bull-board/express", () => ({
+			ExpressAdapter: class {
+				getRouter() {
+					return "router";
+				}
+			},
+		}));
+		vi.doMock("@bull-board/api/bullMQAdapter", () => ({
+			BullMQAdapter: class {},
+		}));
+		vi.doMock("@bull-board/api/bullAdapter", () => ({
+			BullAdapter: class {},
+		}));
+
+		const multiPageScanMock = vi
+			.fn()
+			.mockResolvedValueOnce(["42", ["bull:queue1:id"]])
+			.mockResolvedValueOnce(["0", ["bull:queue2:id"]]);
+
+		vi.doMock("../../src/redis", () => ({
+			client: {
+				scan: multiPageScanMock,
+				connection: "redis-connection",
+				on: vi.fn(),
+				nodes: vi.fn().mockReturnValue([]),
+				duplicate: vi.fn().mockReturnValue({ on: vi.fn() }),
+			},
+			redisConfig: { redis: { host: "localhost", port: 6379 } },
+			isCluster: false,
+		}));
+		vi.doMock("../../src/config", () => ({ config: defaultConfig }));
+		vi.doMock("exponential-backoff", () => ({
+			backOff: vi.fn().mockImplementation((fn) => fn()),
+		}));
+
+		const bull = await import("../../src/bull.js");
+		await bull.bullMain();
+
+		expect(multiPageScanMock).toHaveBeenCalledTimes(2);
+		expect(multiPageScanMock).toHaveBeenNthCalledWith(1, "0", "MATCH", "bull:*", "COUNT", 100);
+		expect(multiPageScanMock).toHaveBeenNthCalledWith(2, "42", "MATCH", "bull:*", "COUNT", 100);
+	});
+
 	it("should discover Bull queues and add them to the board (Bull)", async () => {
 		// Setup mocks with Bull configuration
 		setupCommonMocks({

--- a/tests/unit/bull.test.js
+++ b/tests/unit/bull.test.js
@@ -183,10 +183,12 @@ describe("Bull Queue Setup", () => {
 	});
 
 	it("should accumulate keys across multiple SCAN pages", async () => {
-		vi.doMock("bullmq", () => ({ Queue: vi.fn() }));
+		const multiPageQueueMock = vi.fn();
+		vi.doMock("bullmq", () => ({ Queue: multiPageQueueMock }));
 		vi.doMock("bull", () => ({ default: vi.fn() }));
+		const multiPageSetQueuesMock = vi.fn();
 		vi.doMock("@bull-board/api", () => ({
-			createBullBoard: vi.fn().mockReturnValue({ setQueues: vi.fn() }),
+			createBullBoard: vi.fn().mockReturnValue({ setQueues: multiPageSetQueuesMock }),
 		}));
 		vi.doMock("@bull-board/express", () => ({
 			ExpressAdapter: class {
@@ -226,9 +228,16 @@ describe("Bull Queue Setup", () => {
 		const bull = await import("../../src/bull.js");
 		await bull.bullMain();
 
+		// Verify SCAN pagination
 		expect(multiPageScanMock).toHaveBeenCalledTimes(2);
 		expect(multiPageScanMock).toHaveBeenNthCalledWith(1, "0", "MATCH", "bull:*", "COUNT", 100);
 		expect(multiPageScanMock).toHaveBeenNthCalledWith(2, "42", "MATCH", "bull:*", "COUNT", 100);
+
+		// Verify both queues from different pages were discovered and registered
+		expect(multiPageQueueMock).toHaveBeenCalledTimes(2);
+		expect(multiPageQueueMock).toHaveBeenCalledWith("queue1", expect.any(Object), "redis-connection");
+		expect(multiPageQueueMock).toHaveBeenCalledWith("queue2", expect.any(Object), "redis-connection");
+		expect(multiPageSetQueuesMock).toHaveBeenCalledWith(expect.arrayContaining([expect.any(Object), expect.any(Object)]));
 	});
 
 	it("should discover Bull queues and add them to the board (Bull)", async () => {

--- a/tests/unit/bull.test.js
+++ b/tests/unit/bull.test.js
@@ -88,9 +88,11 @@ describe("Bull Queue Setup", () => {
 
 		// Setup Redis mock
 		clientKeysMock = vi.fn().mockResolvedValue(queueKeys);
+		const clientScanMock = vi.fn().mockResolvedValue(["0", queueKeys]);
 		vi.doMock("../../src/redis", () => ({
 			client: {
 				keys: clientKeysMock,
+				scan: clientScanMock,
 				connection: "redis-connection",
 				on: vi.fn(),
 				nodes: vi.fn().mockReturnValue([]),
@@ -178,6 +180,74 @@ describe("Bull Queue Setup", () => {
 
 		// Verify that setQueues was called with the adapters
 		expect(setQueuesMock).toHaveBeenCalledWith(expect.any(Array));
+	});
+
+	it("should accumulate keys across multiple SCAN pages", async () => {
+		const multiPageQueueMock = vi.fn();
+		vi.doMock("bullmq", () => ({ Queue: multiPageQueueMock }));
+		vi.doMock("bull", () => ({ default: vi.fn() }));
+		const multiPageSetQueuesMock = vi.fn();
+		vi.doMock("@bull-board/api", () => ({
+			createBullBoard: vi.fn().mockReturnValue({ setQueues: multiPageSetQueuesMock }),
+		}));
+		vi.doMock("@bull-board/express", () => ({
+			ExpressAdapter: class {
+				getRouter() {
+					return "router";
+				}
+			},
+		}));
+		vi.doMock("@bull-board/api/bullMQAdapter", () => ({
+			BullMQAdapter: class {},
+		}));
+		vi.doMock("@bull-board/api/bullAdapter", () => ({
+			BullAdapter: class {},
+		}));
+
+		const multiPageScanMock = vi
+			.fn()
+			.mockResolvedValueOnce(["42", ["bull:queue1:id"]])
+			.mockResolvedValueOnce(["0", ["bull:queue2:id"]]);
+
+		vi.doMock("../../src/redis", () => ({
+			client: {
+				scan: multiPageScanMock,
+				connection: "redis-connection",
+				on: vi.fn(),
+				nodes: vi.fn().mockReturnValue([]),
+				duplicate: vi.fn().mockReturnValue({ on: vi.fn() }),
+			},
+			redisConfig: { redis: { host: "localhost", port: 6379 } },
+			isCluster: false,
+		}));
+		vi.doMock("../../src/config", () => ({ config: defaultConfig }));
+		vi.doMock("exponential-backoff", () => ({
+			backOff: vi.fn().mockImplementation((fn) => fn()),
+		}));
+
+		const bull = await import("../../src/bull.js");
+		await bull.bullMain();
+
+		// Verify SCAN pagination
+		expect(multiPageScanMock).toHaveBeenCalledTimes(2);
+		expect(multiPageScanMock).toHaveBeenNthCalledWith(1, "0", "MATCH", "bull:*", "COUNT", 100);
+		expect(multiPageScanMock).toHaveBeenNthCalledWith(2, "42", "MATCH", "bull:*", "COUNT", 100);
+
+		// Verify both queues from different pages were discovered and registered
+		expect(multiPageQueueMock).toHaveBeenCalledTimes(2);
+		expect(multiPageQueueMock).toHaveBeenCalledWith(
+			"queue1",
+			expect.any(Object),
+			"redis-connection",
+		);
+		expect(multiPageQueueMock).toHaveBeenCalledWith(
+			"queue2",
+			expect.any(Object),
+			"redis-connection",
+		);
+		expect(multiPageSetQueuesMock).toHaveBeenCalledWith(
+			expect.arrayContaining([expect.any(Object), expect.any(Object)]),
+		);
 	});
 
 	it("should discover Bull queues and add them to the board (Bull)", async () => {
@@ -348,8 +418,8 @@ describe("Bull Queue Setup", () => {
 			}));
 
 			// Setup Redis mock with cluster support
-			const mockNode1 = { keys: vi.fn().mockResolvedValue(queueKeys.slice(0, 1)) };
-			const mockNode2 = { keys: vi.fn().mockResolvedValue(queueKeys.slice(1)) };
+			const mockNode1 = { scan: vi.fn().mockResolvedValue(["0", queueKeys.slice(0, 1)]) };
+			const mockNode2 = { scan: vi.fn().mockResolvedValue(["0", queueKeys.slice(1)]) };
 			clientKeysMock = vi.fn().mockResolvedValue(queueKeys);
 
 			const mockClient = {
@@ -390,8 +460,8 @@ describe("Bull Queue Setup", () => {
 			const bull = await import("../../src/bull.js");
 			await bull.bullMain();
 
-			expect(mockNode1.keys).toHaveBeenCalledWith("bull:*");
-			expect(mockNode2.keys).toHaveBeenCalledWith("bull:*");
+			expect(mockNode1.scan).toHaveBeenCalledWith("0", "MATCH", "bull:*", "COUNT", 100);
+			expect(mockNode2.scan).toHaveBeenCalledWith("0", "MATCH", "bull:*", "COUNT", 100);
 			expect(BullMQAdapterMock).toHaveBeenCalledTimes(2);
 			expect(setQueuesMock).toHaveBeenCalledWith(expect.any(Array));
 		});
@@ -454,19 +524,47 @@ describe("Bull Queue Setup", () => {
 		});
 
 		it("should throw when no master nodes are available", async () => {
-			const { mockClient } = setupClusterMocks();
-
-			// Override nodes to return empty array on the already-registered mock
-			// to avoid re-mocking the same module (which can race across test files).
-			mockClient.nodes.mockReturnValue([]);
+			vi.doMock("bullmq", () => ({ Queue: vi.fn() }));
+			vi.doMock("bull", () => ({ default: vi.fn() }));
+			vi.doMock("@bull-board/api", () => ({
+				createBullBoard: vi.fn().mockReturnValue({ setQueues: vi.fn() }),
+			}));
+			vi.doMock("@bull-board/express", () => ({
+				ExpressAdapter: class {
+					getRouter() {
+						return "router";
+					}
+				},
+			}));
+			vi.doMock("@bull-board/api/bullMQAdapter", () => ({
+				BullMQAdapter: class {},
+			}));
+			vi.doMock("@bull-board/api/bullAdapter", () => ({
+				BullAdapter: class {},
+			}));
+			vi.doMock("../../src/redis", () => ({
+				client: {
+					keys: vi.fn(),
+					connection: "redis-connection",
+					on: vi.fn(),
+					nodes: vi.fn().mockReturnValue([]),
+					duplicate: vi.fn().mockReturnValue({ on: vi.fn() }),
+				},
+				redisConfig: { redis: { host: "localhost", port: 6379 } },
+				isCluster: true,
+			}));
+			vi.doMock("../../src/config", () => ({ config: defaultConfig }));
+			vi.doMock("exponential-backoff", () => ({
+				backOff: vi.fn().mockImplementation((fn) => fn()),
+			}));
 
 			const bull = await import("../../src/bull.js");
 			await expect(bull.getBullQueues()).rejects.toThrow("No master nodes available");
 		});
 
 		it("should handle partial node failures gracefully", async () => {
-			const failingNode = { keys: vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) };
-			const workingNode = { keys: vi.fn().mockResolvedValue(["bull:queue1:jobs"]) };
+			const failingNode = { scan: vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) };
+			const workingNode = { scan: vi.fn().mockResolvedValue(["0", ["bull:queue1:jobs"]]) };
 
 			vi.doMock("bullmq", () => ({ Queue: vi.fn() }));
 			vi.doMock("bull", () => ({ default: vi.fn() }));
@@ -518,8 +616,8 @@ describe("Bull Queue Setup", () => {
 		});
 
 		it("should throw when all master nodes fail", async () => {
-			const failingNode1 = { keys: vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) };
-			const failingNode2 = { keys: vi.fn().mockRejectedValue(new Error("ETIMEDOUT")) };
+			const failingNode1 = { scan: vi.fn().mockRejectedValue(new Error("ECONNREFUSED")) };
+			const failingNode2 = { scan: vi.fn().mockRejectedValue(new Error("ETIMEDOUT")) };
 
 			vi.doMock("bullmq", () => ({ Queue: vi.fn() }));
 			vi.doMock("bull", () => ({ default: vi.fn() }));

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -90,6 +90,9 @@ describe("Configuration", () => {
 			expect(config.BACKOFF_TIME_MULTIPLE).toBe(2);
 			expect(config.BACKOFF_NB_ATTEMPTS).toBe(10);
 
+			// Shutdown configuration
+			expect(config.GRACEFUL_SHUTDOWN_TIMEOUT).toBe(10000);
+
 			// App configuration
 			expect(config.PORT).toBe(3000);
 			expect(config.BULL_BOARD_HOSTNAME).toBe("0.0.0.0");
@@ -336,6 +339,16 @@ describe("Configuration", () => {
 			expect(config.BACKOFF_MAX_DELAY).toBe(10000);
 			expect(config.BACKOFF_TIME_MULTIPLE).toBe(3);
 			expect(config.BACKOFF_NB_ATTEMPTS).toBe(5);
+		});
+	});
+
+	describe("Shutdown Configuration", () => {
+		it("should load GRACEFUL_SHUTDOWN_TIMEOUT from environment variable", async () => {
+			process.env.GRACEFUL_SHUTDOWN_TIMEOUT = "30000";
+
+			const { config } = await getConfig();
+
+			expect(config.GRACEFUL_SHUTDOWN_TIMEOUT).toBe(30000);
 		});
 	});
 

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -328,10 +328,10 @@ describe('Configuration', () => {
 			// Verify that environment variables were loaded correctly
 			expect(config.BULL_PREFIX).toBe('custom-bull');
 			expect(config.BULL_VERSION).toBe('BULL');
-			expect(config.BACKOFF_STARTING_DELAY).toBe('1000');
-			expect(config.BACKOFF_MAX_DELAY).toBe('10000');
-			expect(config.BACKOFF_TIME_MULTIPLE).toBe('3');
-			expect(config.BACKOFF_NB_ATTEMPTS).toBe('5');
+			expect(config.BACKOFF_STARTING_DELAY).toBe(1000);
+			expect(config.BACKOFF_MAX_DELAY).toBe(10000);
+			expect(config.BACKOFF_TIME_MULTIPLE).toBe(3);
+			expect(config.BACKOFF_NB_ATTEMPTS).toBe(5);
 		});
 	});
 

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -90,6 +90,9 @@ describe("Configuration", () => {
 			expect(config.BACKOFF_TIME_MULTIPLE).toBe(2);
 			expect(config.BACKOFF_NB_ATTEMPTS).toBe(10);
 
+			// Shutdown configuration
+			expect(config.GRACEFUL_SHUTDOWN_TIMEOUT).toBe(10000);
+
 			// App configuration
 			expect(config.PORT).toBe(3000);
 			expect(config.BULL_BOARD_HOSTNAME).toBe("0.0.0.0");
@@ -330,10 +333,58 @@ describe("Configuration", () => {
 			// Verify that environment variables were loaded correctly
 			expect(config.BULL_PREFIX).toBe("custom-bull");
 			expect(config.BULL_VERSION).toBe("BULL");
-			expect(config.BACKOFF_STARTING_DELAY).toBe("1000");
-			expect(config.BACKOFF_MAX_DELAY).toBe("10000");
-			expect(config.BACKOFF_TIME_MULTIPLE).toBe("3");
-			expect(config.BACKOFF_NB_ATTEMPTS).toBe("5");
+			expect(config.BACKOFF_STARTING_DELAY).toBe(1000);
+			expect(config.BACKOFF_MAX_DELAY).toBe(10000);
+			expect(config.BACKOFF_TIME_MULTIPLE).toBe(3);
+			expect(config.BACKOFF_NB_ATTEMPTS).toBe(5);
+		});
+	});
+
+	describe("Shutdown Configuration", () => {
+		it("should load GRACEFUL_SHUTDOWN_TIMEOUT from environment variable", async () => {
+			process.env.GRACEFUL_SHUTDOWN_TIMEOUT = "30000";
+
+			const { config } = await getConfig();
+
+			expect(config.GRACEFUL_SHUTDOWN_TIMEOUT).toBe(30000);
+		});
+	});
+
+	describe("Numeric env parsing", () => {
+		it("should accept 0 as an explicit value, not fall back to default", async () => {
+			process.env.GRACEFUL_SHUTDOWN_TIMEOUT = "0";
+			process.env.BACKOFF_NB_ATTEMPTS = "0";
+
+			const { config } = await getConfig();
+
+			expect(config.GRACEFUL_SHUTDOWN_TIMEOUT).toBe(0);
+			expect(config.BACKOFF_NB_ATTEMPTS).toBe(0);
+		});
+
+		it("should preserve Infinity for BACKOFF_MAX_DELAY", async () => {
+			process.env.BACKOFF_MAX_DELAY = "Infinity";
+
+			const { config } = await getConfig();
+
+			expect(config.BACKOFF_MAX_DELAY).toBe(Infinity);
+		});
+
+		it("should fall back to default when env value is empty string", async () => {
+			process.env.GRACEFUL_SHUTDOWN_TIMEOUT = "";
+			process.env.BACKOFF_STARTING_DELAY = "";
+
+			const { config } = await getConfig();
+
+			expect(config.GRACEFUL_SHUTDOWN_TIMEOUT).toBe(10000);
+			expect(config.BACKOFF_STARTING_DELAY).toBe(500);
+		});
+
+		it("should fall back to default when env value is non-numeric", async () => {
+			process.env.BACKOFF_TIME_MULTIPLE = "not-a-number";
+
+			const { config } = await getConfig();
+
+			expect(config.BACKOFF_TIME_MULTIPLE).toBe(2);
 		});
 	});
 

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -350,6 +350,44 @@ describe("Configuration", () => {
 		});
 	});
 
+	describe("Numeric env parsing", () => {
+		it("should accept 0 as an explicit value, not fall back to default", async () => {
+			process.env.GRACEFUL_SHUTDOWN_TIMEOUT = "0";
+			process.env.BACKOFF_NB_ATTEMPTS = "0";
+
+			const { config } = await getConfig();
+
+			expect(config.GRACEFUL_SHUTDOWN_TIMEOUT).toBe(0);
+			expect(config.BACKOFF_NB_ATTEMPTS).toBe(0);
+		});
+
+		it("should preserve Infinity for BACKOFF_MAX_DELAY", async () => {
+			process.env.BACKOFF_MAX_DELAY = "Infinity";
+
+			const { config } = await getConfig();
+
+			expect(config.BACKOFF_MAX_DELAY).toBe(Infinity);
+		});
+
+		it("should fall back to default when env value is empty string", async () => {
+			process.env.GRACEFUL_SHUTDOWN_TIMEOUT = "";
+			process.env.BACKOFF_STARTING_DELAY = "";
+
+			const { config } = await getConfig();
+
+			expect(config.GRACEFUL_SHUTDOWN_TIMEOUT).toBe(10000);
+			expect(config.BACKOFF_STARTING_DELAY).toBe(500);
+		});
+
+		it("should fall back to default when env value is non-numeric", async () => {
+			process.env.BACKOFF_TIME_MULTIPLE = "not-a-number";
+
+			const { config } = await getConfig();
+
+			expect(config.BACKOFF_TIME_MULTIPLE).toBe(2);
+		});
+	});
+
 	describe("App Configuration", () => {
 		it("should load App configuration from environment variables", async () => {
 			// Set environment variables

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -264,7 +264,7 @@ describe('Express Application', () => {
       await handler(req, res);
 
       // Verify that res.status and res.json were called with the correct arguments
-      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.status).toHaveBeenCalledWith(503);
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
         status: 'error',
         info: expect.objectContaining({

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -336,6 +336,34 @@ describe("Express Application", () => {
 			processExitSpy.mockRestore();
 		});
 
+		it("should still exit when client.quit() rejects during shutdown", async () => {
+			const processOnSpy = vi.spyOn(process, "on");
+			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
+			const redisMock = setupCommonMocks({
+				...defaultConfig,
+				GRACEFUL_SHUTDOWN_TIMEOUT: 10000,
+			});
+			redisMock.client.quit = vi.fn().mockRejectedValue(new Error("Redis quit failed"));
+
+			await import("../../src/index.js");
+
+			const sigtermHandler = processOnSpy.mock.calls.find((call) => call[0] === "SIGTERM")[1];
+
+			await sigtermHandler();
+
+			expect(redisMock.client.quit).toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				"Error closing Redis connection:",
+				expect.any(Error),
+			);
+			expect(processExitSpy).toHaveBeenCalledWith(0);
+
+			processOnSpy.mockRestore();
+			processExitSpy.mockRestore();
+			consoleErrorSpy.mockRestore();
+		});
+
 		it("should not shutdown twice on repeated signals", async () => {
 			const processOnSpy = vi.spyOn(process, "on");
 			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -7,6 +7,7 @@ describe("Express Application", () => {
 	// Common mocks
 	let mockApp;
 	let mockRouter;
+	let mockServer;
 	let consoleSpy;
 
 	// Default config
@@ -27,7 +28,13 @@ describe("Express Application", () => {
 			use: vi.fn(),
 			listen: vi.fn().mockImplementation((port, hostname, callback) => {
 				if (callback) callback();
-				return { on: vi.fn() };
+				mockServer = {
+					on: vi.fn(),
+					close: vi.fn().mockImplementation((cb) => {
+						if (cb) cb();
+					}),
+				};
+				return mockServer;
 			}),
 			get: vi.fn(),
 		};
@@ -291,6 +298,64 @@ describe("Express Application", () => {
 					}),
 				}),
 			);
+		});
+	});
+
+	describe("Graceful Shutdown", () => {
+		it("should register SIGTERM and SIGINT handlers", async () => {
+			const processOnSpy = vi.spyOn(process, "on");
+			setupCommonMocks();
+
+			await import("../../src/index.js");
+
+			expect(processOnSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+			expect(processOnSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+			processOnSpy.mockRestore();
+		});
+
+		it("should close server and Redis connection on SIGTERM", async () => {
+			const processOnSpy = vi.spyOn(process, "on");
+			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+			const redisMock = setupCommonMocks({
+				...defaultConfig,
+				GRACEFUL_SHUTDOWN_TIMEOUT: 10000,
+			});
+			redisMock.client.quit = vi.fn().mockResolvedValue("OK");
+
+			await import("../../src/index.js");
+
+			const sigtermHandler = processOnSpy.mock.calls.find((call) => call[0] === "SIGTERM")[1];
+
+			await sigtermHandler();
+
+			expect(mockServer.close).toHaveBeenCalledWith(expect.any(Function));
+			expect(redisMock.client.quit).toHaveBeenCalled();
+			expect(processExitSpy).toHaveBeenCalledWith(0);
+
+			processOnSpy.mockRestore();
+			processExitSpy.mockRestore();
+		});
+
+		it("should not shutdown twice on repeated signals", async () => {
+			const processOnSpy = vi.spyOn(process, "on");
+			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+			const redisMock = setupCommonMocks({
+				...defaultConfig,
+				GRACEFUL_SHUTDOWN_TIMEOUT: 10000,
+			});
+			redisMock.client.quit = vi.fn().mockResolvedValue("OK");
+
+			await import("../../src/index.js");
+
+			const sigtermHandler = processOnSpy.mock.calls.find((call) => call[0] === "SIGTERM")[1];
+
+			await sigtermHandler();
+			await sigtermHandler();
+
+			expect(mockServer.close).toHaveBeenCalledTimes(1);
+
+			processOnSpy.mockRestore();
+			processExitSpy.mockRestore();
 		});
 	});
 });

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -330,7 +330,7 @@ describe("Express Application", () => {
 			processExitSpy.mockRestore();
 		});
 
-		it("should still exit when client.quit() rejects during shutdown", async () => {
+		it("should exit with code 1 when client.quit() rejects during shutdown", async () => {
 			const processOnSpy = vi.spyOn(process, "on");
 			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
 			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
@@ -351,7 +351,7 @@ describe("Express Application", () => {
 				"Error closing Redis connection:",
 				expect.any(Error),
 			);
-			expect(processExitSpy).toHaveBeenCalledWith(0);
+			expect(processExitSpy).toHaveBeenCalledWith(1);
 
 			processOnSpy.mockRestore();
 			processExitSpy.mockRestore();

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -358,6 +358,37 @@ describe("Express Application", () => {
 			consoleErrorSpy.mockRestore();
 		});
 
+		it("should force-exit with code 1 when shutdown exceeds the timeout", async () => {
+			vi.useFakeTimers();
+			const processOnSpy = vi.spyOn(process, "on");
+			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
+			setupCommonMocks({
+				...defaultConfig,
+				GRACEFUL_SHUTDOWN_TIMEOUT: 5000,
+			});
+
+			await import("../../src/index.js");
+
+			// Simulate a hanging server.close() — never invokes its callback
+			mockServer.close = vi.fn();
+
+			const sigtermHandler = processOnSpy.mock.calls.find((call) => call[0] === "SIGTERM")[1];
+			sigtermHandler();
+
+			expect(processExitSpy).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(5000);
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith("Forced shutdown after timeout");
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+
+			vi.useRealTimers();
+			processOnSpy.mockRestore();
+			processExitSpy.mockRestore();
+			consoleErrorSpy.mockRestore();
+		});
+
 		it("should not shutdown twice on repeated signals", async () => {
 			const processOnSpy = vi.spyOn(process, "on");
 			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -7,6 +7,7 @@ describe("Express Application", () => {
 	// Common mocks
 	let mockApp;
 	let mockRouter;
+	let mockServer;
 	let consoleSpy;
 
 	// Default config
@@ -27,7 +28,13 @@ describe("Express Application", () => {
 			use: vi.fn(),
 			listen: vi.fn().mockImplementation((port, hostname, callback) => {
 				if (callback) callback();
-				return { on: vi.fn() };
+				mockServer = {
+					on: vi.fn(),
+					close: vi.fn().mockImplementation((cb) => {
+						if (cb) cb();
+					}),
+				};
+				return mockServer;
 			}),
 			get: vi.fn(),
 		};
@@ -272,7 +279,7 @@ describe("Express Application", () => {
 			await handler(req, res);
 
 			// Verify that res.status and res.json were called with the correct arguments
-			expect(res.status).toHaveBeenCalledWith(200);
+			expect(res.status).toHaveBeenCalledWith(503);
 			expect(res.json).toHaveBeenCalledWith(
 				expect.objectContaining({
 					status: "error",
@@ -285,6 +292,153 @@ describe("Express Application", () => {
 					}),
 				}),
 			);
+		});
+	});
+
+	describe("Graceful Shutdown", () => {
+		it("should register SIGTERM and SIGINT handlers", async () => {
+			const processOnSpy = vi.spyOn(process, "on");
+			setupCommonMocks();
+
+			await import("../../src/index.js");
+
+			expect(processOnSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+			expect(processOnSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+			processOnSpy.mockRestore();
+		});
+
+		it("should close server and Redis connection on SIGTERM", async () => {
+			const processOnSpy = vi.spyOn(process, "on");
+			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+			const redisMock = setupCommonMocks({
+				...defaultConfig,
+				GRACEFUL_SHUTDOWN_TIMEOUT: 10000,
+			});
+			redisMock.client.quit = vi.fn().mockResolvedValue("OK");
+
+			await import("../../src/index.js");
+
+			const sigtermHandler = processOnSpy.mock.calls.find((call) => call[0] === "SIGTERM")[1];
+
+			await sigtermHandler();
+
+			expect(mockServer.close).toHaveBeenCalledWith(expect.any(Function));
+			expect(redisMock.client.quit).toHaveBeenCalled();
+			expect(processExitSpy).toHaveBeenCalledWith(0);
+
+			processOnSpy.mockRestore();
+			processExitSpy.mockRestore();
+		});
+
+		it("should exit with code 1 when client.quit() rejects during shutdown", async () => {
+			const processOnSpy = vi.spyOn(process, "on");
+			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
+			const redisMock = setupCommonMocks({
+				...defaultConfig,
+				GRACEFUL_SHUTDOWN_TIMEOUT: 10000,
+			});
+			redisMock.client.quit = vi.fn().mockRejectedValue(new Error("Redis quit failed"));
+
+			await import("../../src/index.js");
+
+			const sigtermHandler = processOnSpy.mock.calls.find((call) => call[0] === "SIGTERM")[1];
+
+			await sigtermHandler();
+
+			expect(redisMock.client.quit).toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				"Error closing Redis connection:",
+				expect.any(Error),
+			);
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+
+			processOnSpy.mockRestore();
+			processExitSpy.mockRestore();
+			consoleErrorSpy.mockRestore();
+		});
+
+		it("should force-exit with code 1 when shutdown exceeds the timeout", async () => {
+			vi.useFakeTimers();
+			const processOnSpy = vi.spyOn(process, "on");
+			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+			const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation();
+			setupCommonMocks({
+				...defaultConfig,
+				GRACEFUL_SHUTDOWN_TIMEOUT: 5000,
+			});
+
+			await import("../../src/index.js");
+
+			// Simulate a hanging server.close() — never invokes its callback
+			mockServer.close = vi.fn();
+
+			const sigtermHandler = processOnSpy.mock.calls.find((call) => call[0] === "SIGTERM")[1];
+			sigtermHandler();
+
+			expect(processExitSpy).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(5000);
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith("Forced shutdown after timeout");
+			expect(processExitSpy).toHaveBeenCalledWith(1);
+
+			vi.useRealTimers();
+			processOnSpy.mockRestore();
+			processExitSpy.mockRestore();
+			consoleErrorSpy.mockRestore();
+		});
+
+		it("does not arm the force-kill timer when the timeout is 0", async () => {
+			vi.useFakeTimers();
+			const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+			const processOnSpy = vi.spyOn(process, "on");
+			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+			setupCommonMocks({
+				...defaultConfig,
+				GRACEFUL_SHUTDOWN_TIMEOUT: 0,
+			});
+
+			await import("../../src/index.js");
+
+			// Simulate a hanging server.close() — never invokes its callback
+			mockServer.close = vi.fn();
+
+			const sigtermHandler = processOnSpy.mock.calls.find((call) => call[0] === "SIGTERM")[1];
+			sigtermHandler();
+
+			expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(60000);
+
+			expect(processExitSpy).not.toHaveBeenCalled();
+
+			vi.useRealTimers();
+			setTimeoutSpy.mockRestore();
+			processOnSpy.mockRestore();
+			processExitSpy.mockRestore();
+		});
+
+		it("should not shutdown twice on repeated signals", async () => {
+			const processOnSpy = vi.spyOn(process, "on");
+			const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => {});
+			const redisMock = setupCommonMocks({
+				...defaultConfig,
+				GRACEFUL_SHUTDOWN_TIMEOUT: 10000,
+			});
+			redisMock.client.quit = vi.fn().mockResolvedValue("OK");
+
+			await import("../../src/index.js");
+
+			const sigtermHandler = processOnSpy.mock.calls.find((call) => call[0] === "SIGTERM")[1];
+
+			await sigtermHandler();
+			await sigtermHandler();
+
+			expect(mockServer.close).toHaveBeenCalledTimes(1);
+
+			processOnSpy.mockRestore();
+			processExitSpy.mockRestore();
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Replace the blocking `KEYS` command with incremental `SCAN` for queue discovery (single-node and per-master in cluster mode), with a named `COUNT` hint and key de-duplication on both paths.
- Add graceful shutdown handling for `SIGTERM`/`SIGINT` (configurable via `GRACEFUL_SHUTDOWN_TIMEOUT`).
- Close the Redis discovery client on shutdown to prevent connection leaks.
- Coerce `BACKOFF_*` and `GRACEFUL_SHUTDOWN_TIMEOUT` env vars to `Number` and treat `0` as a valid value (was silently falling back to the default because of `Number(env) || default`).
- Extract Bull/BullMQ adapter creation into helpers.

## Behavior changes

- **`/healthcheck` now returns `503` when Redis is unreachable** (was always `200`). Use as a Kubernetes `readinessProbe`, not `livenessProbe` — see README. Liveness probes that asserted `HTTP 200` will start failing on Redis errors.
- **Process exits with code `1`** when `client.quit()` rejects during shutdown (previously always `0`). Aligns with the forced-timeout path.
- **`GRACEFUL_SHUTDOWN_TIMEOUT=0` disables the force-kill timer** and waits for a clean close (instead of forcing an immediate exit).

## Follow-ups

- #387 — Close registered Bull/BullMQ queue connections during graceful shutdown (currently only the discovery client is closed).

## Test plan

- [x] `npm test` passes — 123 tests, including SCAN pagination, cluster fan-out, partial node failures, SIGTERM/SIGINT handlers, idempotent shutdown, quit-rejection path, forced-timeout path, timeout-disabled path, healthcheck 503, numeric env parsing edge cases
- [ ] Smoke test against a real Redis with many keys to confirm SCAN-based discovery still finds queues
- [ ] Smoke test SIGTERM in Docker (`docker compose stop`) to confirm clean shutdown logs
