### PR TITLE
ci: add lint and format checks and document workflows

### DIFF
--- a/.github/README_CI.md
+++ b/.github/README_CI.md
@@ -4,12 +4,12 @@
 
 ## Workflows
 
-| Workflow                                               | Triggers                                                    | Purpose                                                                                  |
-|--------------------------------------------------------|-------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| Workflow                                               | Triggers                                                    | Purpose                                                                                                                                             |
+| ------------------------------------------------------ | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`pull-request.yml`](./workflows/pull-request.yml)     | `pull_request` on `master`, `workflow_call`                 | Matrix job running `lint` (oxlint), `format` (oxfmt) and `test:coverage` in parallel; the `test` leg also publishes a coverage report and artifact. |
-| [`docker-publish.yml`](./workflows/docker-publish.yml) | `push` on tags `v*.*.*`, `pull_request` on `master`, manual | Build multi-arch Docker image (`linux/amd64,linux/arm64`) and push to Docker Hub on tag. |
-| [`release.yml`](./workflows/release.yml)               | `push` on `master`, manual                                  | Run `semantic-release` to cut a new version and Github release.                          |
-| [`renovate.yml`](./workflows/renovate.yml)             | Cron `00 1 * * 1` (Mondays 01:00 UTC), manual               | Self-hosted Renovate run to open dependency-update PRs.                                  |
+| [`docker-publish.yml`](./workflows/docker-publish.yml) | `push` on tags `v*.*.*`, `pull_request` on `master`, manual | Build multi-arch Docker image (`linux/amd64,linux/arm64`) and push to Docker Hub on tag.                                                            |
+| [`release.yml`](./workflows/release.yml)               | `push` on `master`, manual                                  | Run `semantic-release` to cut a new version and Github release.                                                                                     |
+| [`renovate.yml`](./workflows/renovate.yml)             | Cron `00 1 * * 1` (Mondays 01:00 UTC), manual               | Self-hosted Renovate run to open dependency-update PRs.                                                                                             |
 
 ## Dependencies
 
@@ -35,7 +35,7 @@
 ## Secrets
 
 | Name              | Used by              | Description                                                                   |
-|-------------------|----------------------|-------------------------------------------------------------------------------|
+| ----------------- | -------------------- | ----------------------------------------------------------------------------- |
 | `DOCKERHUB_TOKEN` | `docker-publish.yml` | Docker Hub access token for `venatum` to push the `venatum/bull-board` image. |
 | `SEMANTIC_TOKEN`  | `release.yml`        | GitHub token used by `semantic-release` to create tags and releases.          |
 | `RENOVATE_TOKEN`  | `renovate.yml`       | GitHub token used by the self-hosted Renovate run to open PRs.                |

--- a/.github/README_CI.md
+++ b/.github/README_CI.md
@@ -1,0 +1,47 @@
+# Github CI/CD
+
+> CI/CD overview for `bull-board-docker`. Workflows live under [`.github/workflows/`](./workflows).
+
+## Workflows
+
+| Workflow                                               | Triggers                                                    | Purpose                                                                                  |
+|--------------------------------------------------------|-------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| [`pull-request.yml`](./workflows/pull-request.yml)     | `pull_request` on `master`, `workflow_call`                 | Matrix job running `lint` (oxlint), `format` (oxfmt) and `test:coverage` in parallel; the `test` leg also publishes a coverage report and artifact. |
+| [`docker-publish.yml`](./workflows/docker-publish.yml) | `push` on tags `v*.*.*`, `pull_request` on `master`, manual | Build multi-arch Docker image (`linux/amd64,linux/arm64`) and push to Docker Hub on tag. |
+| [`release.yml`](./workflows/release.yml)               | `push` on `master`, manual                                  | Run `semantic-release` to cut a new version and Github release.                          |
+| [`renovate.yml`](./workflows/renovate.yml)             | Cron `00 1 * * 1` (Mondays 01:00 UTC), manual               | Self-hosted Renovate run to open dependency-update PRs.                                  |
+
+## Dependencies
+
+### Github
+
+- [actions/checkout@v6](https://github.com/actions/checkout)
+- [actions/setup-node@v6](https://github.com/actions/setup-node)
+- [actions/upload-artifact@v7](https://github.com/actions/upload-artifact)
+
+### Docker
+
+- [docker/setup-qemu-action@v4](https://github.com/docker/setup-qemu-action)
+- [docker/setup-buildx-action@v4](https://github.com/docker/setup-buildx-action)
+- [docker/login-action@v4](https://github.com/docker/login-action)
+- [docker/metadata-action@v6](https://github.com/docker/metadata-action)
+- [docker/build-push-action@v7](https://github.com/docker/build-push-action)
+
+### Others
+
+- [davelosert/vitest-coverage-report-action@v2](https://github.com/davelosert/vitest-coverage-report-action)
+- [renovatebot/github-action@v46.1.13](https://github.com/renovatebot/github-action)
+
+## Secrets
+
+| Name              | Used by              | Description                                                                   |
+|-------------------|----------------------|-------------------------------------------------------------------------------|
+| `DOCKERHUB_TOKEN` | `docker-publish.yml` | Docker Hub access token for `venatum` to push the `venatum/bull-board` image. |
+| `SEMANTIC_TOKEN`  | `release.yml`        | GitHub token used by `semantic-release` to create tags and releases.          |
+| `RENOVATE_TOKEN`  | `renovate.yml`       | GitHub token used by the self-hosted Renovate run to open PRs.                |
+
+## Runners
+
+- `ubuntu-latest` (public repository): 4 CPU - 16 GB RAM - 14 GB SSD
+
+[Source: Github](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,13 +6,23 @@ on:
   workflow_call:
 
 jobs:
-  test:
-    name: Run Tests
+  checks:
+    name: ${{ matrix.task }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: lint
+            script: lint
+          - task: format
+            script: format
+          - task: test
+            script: test:coverage
 
     steps:
       - name: Checkout repository
@@ -30,16 +40,17 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm i
+        run: npm ci
 
-      - name: Run test coverage
-        run: npm run test:coverage
+      - name: Run ${{ matrix.task }}
+        run: npm run ${{ matrix.script }}
 
       - name: Report Coverage
-        if: always()
+        if: always() && matrix.task == 'test'
         uses: davelosert/vitest-coverage-report-action@v2
 
       - name: Upload coverage report
+        if: matrix.task == 'test'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ A Healthcheck based on NestJS is available to monitor the status of the containe
 ```
 
 | Field     | Description                                                                                                      | Type            |
-|-----------|------------------------------------------------------------------------------------------------------------------|-----------------|
+| --------- | ---------------------------------------------------------------------------------------------------------------- | --------------- |
 | `status`  | Indicates the overall health status. If any health indicator fails, the status will be 'error'.                  | 'ok' or 'error' |
 | `info`    | Object containing information of each health indicator which is of status 'up', or in other words "healthy".     | object          |
 | `error`   | String containing information of each health indicator which is of status 'down', or in other words "unhealthy". | string          |


### PR DESCRIPTION
## Summary

- `pull-request.yml`: collapse the test job into a matrixed `checks` job that runs `lint` (oxlint), `format` (oxfmt) and `test:coverage` in parallel (`fail-fast: false` so all three report independently). The `test` leg still publishes the coverage comment and uploads the `coverage/` artifact.
- Switch the install step from `npm i` to `npm ci` for reproducible CI builds against `package-lock.json`.
- Add `.github/README_CI.md` documenting workflows, action dependencies, required secrets, and runner specs (modeled on the cloudsync `README_CI.md`).

## Test plan

- [x] CI runs the new `checks (lint)`, `checks (format)`, `checks (test)` legs on this PR.
- [x] Coverage comment and `coverage-report` artifact still appear from the `test` leg.
- [x] All three legs pass green.