### PR TITLE
fix(ui): nest logo size and favicon alternative options correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ Please note that on the interface, the Redis server info button will not work. F
 > Default values come from the original project
 
 - `BULL_BOARD_TITLE` - The Board and page titles (`Bull Dashboard` by default)
-- `BULL_BOARD_LOGO_PATH` - Allows you to specify a different logo (`empty` by default)
-- `BULL_BOARD_LOGO_WIDTH` - `BULL_BOARD_LOGO_PATH` is required
-- `BULL_BOARD_LOGO_HEIGHT` - `BULL_BOARD_LOGO_PATH` is required
-- `BULL_BOARD_FAVICON` - Allows you to specify the default favicon (`empty` by default)
-- `BULL_BOARD_FAVICON_ALTERNATIVE` - `BULL_BOARD_FAVICON` is required
-- `BULL_BOARD_LOCALE` - The locale to use
-- `BULL_BOARD_DATE_FORMATS_SHORT` - The date format to use
-- `BULL_BOARD_DATE_FORMATS_COMMON` - The date format to use
-- `BULL_BOARD_DATE_FORMATS_FULL` - The date format to use
+- `BULL_BOARD_LOGO_PATH` - Path to a custom logo image. Can be a URL or a path if the image is mounted in the container.
+- `BULL_BOARD_LOGO_WIDTH` - Width of the logo (e.g. `100px`, `50%`). Requires `BULL_BOARD_LOGO_PATH`.
+- `BULL_BOARD_LOGO_HEIGHT` - Height of the logo (e.g. `100px`, `auto`). Requires `BULL_BOARD_LOGO_PATH`.
+- `BULL_BOARD_FAVICON` - Path to a custom favicon.
+- `BULL_BOARD_FAVICON_ALTERNATIVE` - Path to an alternative favicon (e.g. for dark mode). Requires `BULL_BOARD_FAVICON`.
+- `BULL_BOARD_LOCALE` - The locale to use (e.g. `fr-FR`, `en-US`).
+- `BULL_BOARD_DATE_FORMATS_SHORT` - Short date format (e.g. `yyyy-MM-dd`).
+- `BULL_BOARD_DATE_FORMATS_COMMON` - Common date format (e.g. `yyyy-MM-dd HH:mm`).
+- `BULL_BOARD_DATE_FORMATS_FULL` - Full date format (e.g. `yyyy-MM-dd HH:mm:ss`).
 
 ### Restrict access with login and password
 

--- a/src/bull.js
+++ b/src/bull.js
@@ -21,17 +21,17 @@ const { setQueues } = createBullBoard({
 			...(config.BULL_BOARD_LOGO_PATH && {
 				boardLogo: {
 					path: config.BULL_BOARD_LOGO_PATH,
+					...(config.BULL_BOARD_LOGO_WIDTH && { width: config.BULL_BOARD_LOGO_WIDTH }),
+					...(config.BULL_BOARD_LOGO_HEIGHT && { height: config.BULL_BOARD_LOGO_HEIGHT }),
 				},
-				...(config.BULL_BOARD_LOGO_WIDTH && { width: config.BULL_BOARD_LOGO_WIDTH }),
-				...(config.BULL_BOARD_LOGO_HEIGHT && { height: config.BULL_BOARD_LOGO_HEIGHT }),
 			}),
 			...(config.BULL_BOARD_FAVICON && {
 				favIcon: {
 					default: config.BULL_BOARD_FAVICON,
+					...(config.BULL_BOARD_FAVICON_ALTERNATIVE && {
+						alternative: config.BULL_BOARD_FAVICON_ALTERNATIVE,
+					}),
 				},
-				...(config.BULL_BOARD_FAVICON_ALTERNATIVE && {
-					alternative: config.BULL_BOARD_FAVICON_ALTERNATIVE,
-				}),
 			}),
 			locale: {
 				...(config.BULL_BOARD_LOCALE && { lng: config.BULL_BOARD_LOCALE }),

--- a/tests/unit/bull.test.js
+++ b/tests/unit/bull.test.js
@@ -454,20 +454,11 @@ describe("Bull Queue Setup", () => {
 		});
 
 		it("should throw when no master nodes are available", async () => {
-			setupClusterMocks();
+			const { mockClient } = setupClusterMocks();
 
-			// Override nodes to return empty array
-			vi.doMock("../../src/redis", () => ({
-				client: {
-					keys: vi.fn(),
-					connection: "redis-connection",
-					on: vi.fn(),
-					nodes: vi.fn().mockReturnValue([]),
-					duplicate: vi.fn().mockReturnValue({ on: vi.fn() }),
-				},
-				redisConfig: { redis: { host: "localhost", port: 6379 } },
-				isCluster: true,
-			}));
+			// Override nodes to return empty array on the already-registered mock
+			// to avoid re-mocking the same module (which can race across test files).
+			mockClient.nodes.mockReturnValue([]);
 
 			const bull = await import("../../src/bull.js");
 			await expect(bull.getBullQueues()).rejects.toThrow("No master nodes available");

--- a/tests/unit/ui-config.test.js
+++ b/tests/unit/ui-config.test.js
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Set NODE_ENV to 'test' to prevent automatic execution of bullMain
+process.env.NODE_ENV = "test";
+
+describe("Bull Board UI Configuration", () => {
+	let createBullBoardMock;
+	let ExpressAdapterMock;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetModules();
+
+		// Setup Bull Board mocks
+		createBullBoardMock = vi.fn().mockReturnValue({
+			setQueues: vi.fn(),
+		});
+		vi.doMock("@bull-board/api", () => ({
+			createBullBoard: createBullBoardMock,
+		}));
+
+		// Setup Express Adapter mock
+		ExpressAdapterMock = vi.fn();
+		vi.doMock("@bull-board/express", () => ({
+			ExpressAdapter: class {
+				constructor(...args) {
+					ExpressAdapterMock(...args);
+				}
+				getRouter() {
+					return "router";
+				}
+			},
+		}));
+
+		// Mock other dependencies to avoid errors
+		vi.doMock("../../src/redis", () => ({
+			client: { connection: "redis-connection" },
+			redisConfig: { redis: {} },
+			isCluster: false,
+		}));
+
+		vi.doMock("bullmq", () => ({ Queue: vi.fn() }));
+		vi.doMock("bull", () => ({ default: vi.fn() }));
+		vi.doMock("@bull-board/api/bullMQAdapter", () => ({ BullMQAdapter: vi.fn() }));
+		vi.doMock("@bull-board/api/bullAdapter", () => ({ BullAdapter: vi.fn() }));
+		vi.doMock("exponential-backoff", () => ({ backOff: vi.fn() }));
+	});
+
+	it("should have correct nesting for all UI options in uiConfig", async () => {
+		const mockConfig = {
+			BULL_BOARD_TITLE: "Custom Title",
+			BULL_BOARD_LOGO_PATH: "/path/to/logo.png",
+			BULL_BOARD_LOGO_WIDTH: "100px",
+			BULL_BOARD_LOGO_HEIGHT: "50px",
+			BULL_BOARD_FAVICON: "/path/to/favicon.ico",
+			BULL_BOARD_FAVICON_ALTERNATIVE: "/path/to/alt-favicon.ico",
+			BULL_BOARD_LOCALE: "fr-FR",
+			BULL_BOARD_DATE_FORMATS_SHORT: "yyyy-MM-dd",
+			BULL_BOARD_DATE_FORMATS_COMMON: "yyyy-MM-dd HH:mm",
+			BULL_BOARD_DATE_FORMATS_FULL: "yyyy-MM-dd HH:mm:ss",
+		};
+
+		vi.doMock("../../src/config", () => ({
+			config: mockConfig,
+		}));
+
+		await import("../../src/bull");
+
+		expect(createBullBoardMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				options: expect.objectContaining({
+					uiConfig: expect.objectContaining({
+						boardTitle: "Custom Title",
+						boardLogo: {
+							path: "/path/to/logo.png",
+							width: "100px",
+							height: "50px",
+						},
+						favIcon: {
+							default: "/path/to/favicon.ico",
+							alternative: "/path/to/alt-favicon.ico",
+						},
+						locale: {
+							lng: "fr-FR",
+						},
+						dateFormats: {
+							short: "yyyy-MM-dd",
+							common: "yyyy-MM-dd HH:mm",
+							full: "yyyy-MM-dd HH:mm:ss",
+						},
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("should handle missing optional UI properties", async () => {
+		const mockConfig = {
+			BULL_BOARD_TITLE: "Title Only",
+			// Other properties are undefined
+		};
+
+		vi.doMock("../../src/config", () => ({
+			config: mockConfig,
+		}));
+
+		await import("../../src/bull");
+
+		expect(createBullBoardMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				options: expect.objectContaining({
+					uiConfig: {
+						boardTitle: "Title Only",
+						locale: {},
+						dateFormats: {},
+					},
+				}),
+			}),
+		);
+	});
+
+	it("should ignore logo width/height when BULL_BOARD_LOGO_PATH is missing", async () => {
+		const mockConfig = {
+			BULL_BOARD_LOGO_WIDTH: "100px",
+			BULL_BOARD_LOGO_HEIGHT: "50px",
+		};
+
+		vi.doMock("../../src/config", () => ({
+			config: mockConfig,
+		}));
+
+		await import("../../src/bull");
+
+		const uiConfig = createBullBoardMock.mock.calls[0][0].options.uiConfig;
+		expect(uiConfig).not.toHaveProperty("boardLogo");
+	});
+
+	it("should ignore favicon alternative when BULL_BOARD_FAVICON is missing", async () => {
+		const mockConfig = {
+			BULL_BOARD_FAVICON_ALTERNATIVE: "/path/to/alt-favicon.ico",
+		};
+
+		vi.doMock("../../src/config", () => ({
+			config: mockConfig,
+		}));
+
+		await import("../../src/bull");
+
+		const uiConfig = createBullBoardMock.mock.calls[0][0].options.uiConfig;
+		expect(uiConfig).not.toHaveProperty("favIcon");
+	});
+
+	it("should include logo with only a path when width/height are not set", async () => {
+		const mockConfig = {
+			BULL_BOARD_LOGO_PATH: "/path/to/logo.png",
+			BULL_BOARD_FAVICON: "/path/to/favicon.ico",
+		};
+
+		vi.doMock("../../src/config", () => ({
+			config: mockConfig,
+		}));
+
+		await import("../../src/bull");
+
+		const uiConfig = createBullBoardMock.mock.calls[0][0].options.uiConfig;
+		expect(uiConfig.boardLogo).toEqual({ path: "/path/to/logo.png" });
+		expect(uiConfig.favIcon).toEqual({ default: "/path/to/favicon.ico" });
+	});
+});


### PR DESCRIPTION
## Context

Closes #397

The environment variables `BULL_BOARD_LOGO_WIDTH`, `BULL_BOARD_LOGO_HEIGHT` and `BULL_BOARD_FAVICON_ALTERNATIVE` were ignored because they were spread at the wrong level in `uiConfig`.

## Changes

- `src/bull.js`: correctly nest `width`/`height` inside `boardLogo` and `alternative` inside `favIcon`.
- `tests/unit/ui-config.test.js`: add edge-case tests (width/height ignored without `LOGO_PATH`, `alternative` ignored without `FAVICON`, logo with path only).
- `tests/unit/bull.test.js`: stabilize a flaky cluster test.
- `README.md`: update documentation for the logo/favicon variables.

## Verification

- `vitest run`: 7 files / 111 tests passing.
- `oxfmt --check` and `oxlint`: 0 issues.